### PR TITLE
New UI with Light/Dark theme (.net-9.0 default fluent theme)

### DIFF
--- a/FF7RebirthDataObjectEditor/App.xaml
+++ b/FF7RebirthDataObjectEditor/App.xaml
@@ -1,8 +1,13 @@
 ﻿<Application x:Class="FF7RebirthDataObjectEditor.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             ThemeMode="System"
              StartupUri="MainWindow.xaml">
-    <Application.Resources>
-         
-    </Application.Resources>
+  <Application.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/PresentationFramework.Fluent;component/Themes/Fluent.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </Application.Resources>
 </Application>

--- a/FF7RebirthDataObjectEditor/FF7RebirthDataObjectEditor.csproj
+++ b/FF7RebirthDataObjectEditor/FF7RebirthDataObjectEditor.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net8.0-windows</TargetFramework>
+        <TargetFramework>net9.0-windows7.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <UseWPF>true</UseWPF>

--- a/FF7RebirthDataObjectEditor/PropertyGridControl.xaml.cs
+++ b/FF7RebirthDataObjectEditor/PropertyGridControl.xaml.cs
@@ -11,6 +11,7 @@ namespace FF7RebirthDataObjectEditor;
 public partial class PropertyGridControl : UserControl
 {
     private SolidColorBrush transparentBrush = new SolidColorBrush(Color.FromArgb(0, 0, 0, 0));
+    private Style? buttonStyle;
 
     public ObservableCollection<EntryRow> AssetEntries
 	{
@@ -24,6 +25,22 @@ public partial class PropertyGridControl : UserControl
 	public PropertyGridControl()
 	{
 		InitializeComponent();
+        Style? baseStyle = Application.Current.TryFindResource(typeof(Button)) as Style;
+        if (baseStyle == null)
+            return;
+        buttonStyle = new Style()
+        {
+            BasedOn = baseStyle,
+            TargetType = typeof(Button)
+        };
+        DataTrigger rowSelectedTrigger = new DataTrigger();
+        var binding = new Binding("IsSelected");
+        binding.RelativeSource = new RelativeSource(RelativeSourceMode.FindAncestor, typeof(DataGridRow),1);
+        rowSelectedTrigger.Binding = binding;
+        rowSelectedTrigger.Value = true;
+        var dynamicResource = new DynamicResourceExtension("DataGridRowSelectedForegroundThemeBrush");
+        rowSelectedTrigger.Setters.Add(new Setter(Button.ForegroundProperty, dynamicResource));
+        buttonStyle.Triggers.Add(rowSelectedTrigger);
     }
 	
     public void GenerateColumns(bool withEntryColumn)
@@ -61,6 +78,9 @@ public partial class PropertyGridControl : UserControl
                 buttonFactory.SetValue(Button.HorizontalContentAlignmentProperty, HorizontalAlignment.Left);
                 buttonFactory.SetValue(Button.HorizontalAlignmentProperty, HorizontalAlignment.Stretch);
                 buttonFactory.SetValue(Button.BackgroundProperty, transparentBrush);
+
+                if(buttonStyle != null)
+                    buttonFactory.SetValue(Button.StyleProperty, buttonStyle);
                 assetDataGrid.Columns.Add(new DataGridTemplateColumn
                 {
                     Header = properties[i].Name,

--- a/FF7RebirthDataObjectEditor/PropertyGridControl.xaml.cs
+++ b/FF7RebirthDataObjectEditor/PropertyGridControl.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
+using System.Windows.Media;
 using FF7R2.DataObject;
 using FF7RebirthDataObjectEditor.FF7Types;
 
@@ -9,7 +10,9 @@ namespace FF7RebirthDataObjectEditor;
 
 public partial class PropertyGridControl : UserControl
 {
-	public ObservableCollection<EntryRow> AssetEntries
+    private SolidColorBrush transparentBrush = new SolidColorBrush(Color.FromArgb(0, 0, 0, 0));
+
+    public ObservableCollection<EntryRow> AssetEntries
 	{
 		get { return (ObservableCollection<EntryRow>)GetValue(AssetEntriesProperty); }
 		set { SetValue(AssetEntriesProperty, value); }
@@ -56,6 +59,8 @@ public partial class PropertyGridControl : UserControl
                 buttonFactory.SetBinding(Button.TagProperty, new Binding($"Data.Properties[{i}]"));
                 // buttonFactory.SetBinding( Button.DataContextProperty, new Binding($"Data.Properties[{0}]"));
                 buttonFactory.SetValue(Button.HorizontalContentAlignmentProperty, HorizontalAlignment.Left);
+                buttonFactory.SetValue(Button.HorizontalAlignmentProperty, HorizontalAlignment.Stretch);
+                buttonFactory.SetValue(Button.BackgroundProperty, transparentBrush);
                 assetDataGrid.Columns.Add(new DataGridTemplateColumn
                 {
                     Header = properties[i].Name,

--- a/FF7RebirthEditor.sln
+++ b/FF7RebirthEditor.sln
@@ -1,5 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35806.99 d17.13
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FF7RebirthDataObjectEditor", "FF7RebirthDataObjectEditor\FF7RebirthDataObjectEditor.csproj", "{670BBE4B-A355-4C49-AEA8-4D7E55848EFE}"
 EndProject
 Global
@@ -12,5 +15,11 @@ Global
 		{670BBE4B-A355-4C49-AEA8-4D7E55848EFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{670BBE4B-A355-4C49-AEA8-4D7E55848EFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{670BBE4B-A355-4C49-AEA8-4D7E55848EFE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {46CE70B1-5FBB-4391-8CFC-BD54F5656B4B}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
1. Updated to .net-9.0 which enabled themes.
2. Added standard fluent theme.
3. Did some changes to cell buttons to fit better with the new theme and to keep the text buttons on a selected row visible.
